### PR TITLE
カスタムドメインを破棄するので、README.md にあるブログの URL を更新する

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@
 
 モダンな Web フロントエンドの技術を中心に発信する技術ブログ。
 
-[https://blog.kuroite.dev](https://blog.kuroite.dev)
+Now [blog](https://6110e97ea0112cda1621b1ba--boring-carson-44c8be.netlify.app/)
+Archived [https://blog.kuroite.dev](https://blog.kuroite.dev)
 
 [<img src="./docs/assets/lighthouse.png" height="100px" alt="lighthouse 結果画像（https://blog.kuroite.dev/blog/how-to-back-up-your-data-fast-ignoring-extraneous-files/）" />](https://blog.kuroite.dev/blog/how-to-back-up-your-data-fast-ignoring-extraneous-files/)
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@
 
 モダンな Web フロントエンドの技術を中心に発信する技術ブログ。
 
-Now [blog](https://6110e97ea0112cda1621b1ba--boring-carson-44c8be.netlify.app/)
-Archived [https://blog.kuroite.dev](https://blog.kuroite.dev)
+[blog](https://6110e97ea0112cda1621b1ba--boring-carson-44c8be.netlify.app/)
+
+(Archived [https://blog.kuroite.dev](https://blog.kuroite.dev))
 
 [<img src="./docs/assets/lighthouse.png" height="100px" alt="lighthouse 結果画像（https://blog.kuroite.dev/blog/how-to-back-up-your-data-fast-ignoring-extraneous-files/）" />](https://blog.kuroite.dev/blog/how-to-back-up-your-data-fast-ignoring-extraneous-files/)
 


### PR DESCRIPTION
## 概要

カスタムドメインを破棄するので、README.md にあるブログの URL を更新する
詳細は、https://github.com/kuro-kuroite/kuroite/pull/138 

### 機能追加や修正の背景・目的（一言で目的を伝えるならば）

カスタムドメインを破棄する影響でブログのURLが見られなくなるため。
回避策として、当時の最新の Netlify URL に更新する対応にした。
Netlify も使わなくなった場合、いよいよ公開停止する予定。

#### どの種類の PR か（check at least one）

- [ ] 作業中（WIP）
- [ ] バグ修正
- [ ] 機能改善・追加
- [ ] コードスタイルによる修正
- [ ] Refactor
- [ ] ビルド関連の変更
- [x] Other、please describe: ドメイン破棄

#### この PR は大きな変化をもたらしますか（check one）

- [ ] Yes
- [x] No

#### この PR は破壊的変更をもたらしますか（check one）

- [ ] Yes
- [x] No

#### どの部分を中心に確認してほしいのか、どんなフィードバックを望んでいるのか（check at least one）

- [ ] コードに目を通して欲しい
- [ ] 技術的な議論がしたい
- [ ] 設計について批評してほしい
- [ ] 文言を確認してほしい
- [x] Other、please describe: 変更したURLでブログにアクセス出来るか？

### 機能追加や修正の概要・何が問題か（一言で問題を伝えるならば）

カスタムドメインを破棄する影響でブログのURLが見られなくなる。

### 機能追加や修正の経緯（可能な限り過去から現在の状況と今後起こりうる可能性を詳細に）

詳細は、https://github.com/kuro-kuroite/kuroite/pull/138 で説明したが、カスタムドメインを破棄する。
カスタムドメインを破棄する影響でブログのURLが見られなくなるので、ブログ URL の変更が必要になった。

結論上手くいかなかったが、以下にトライした。
https://github.com/kuro-kuroite/kuroite/pull/138 で GitHub Pages に移行しようとしたが、そもそもの build が通らない。
これは、バージョンが古すぎるためだろう。
更新する余裕はないので、一旦パス。

ただ、アーカイブとして公開しておきたかったので、回避策として以下を採用した。
当時の最新の Netlify URL を利用する。

### 期待されるふるまい

- [x] 変更したNetlify の最新(古い) URLでブログにアクセス出来るか？

### 実際のふるまい

- [x] 変更したNetlify の最新(古い) URLでブログにアクセス出来るか？

### 再現のサンプルコード（Optional）



#### System configuration



### Other information


